### PR TITLE
Revert "Remove possibly redundant links which show up as alerts in WAVE check"

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -19,6 +19,7 @@ listing:
   - id: books
     contents: 
     - /books
+    - "!books/index.qmd"
     sort: "title"
     type: grid
     categories: false
@@ -30,6 +31,7 @@ listing:
   - id: blog
     contents: 
     - /blog
+    - "!blog/index.qmd"
     sort: "date desc"
     type: grid
     categories: false


### PR DESCRIPTION
Reverts nhs-r-community/nhs-r-community#72

Requires lines to prevent the page being relinked to and doesn't remove redundant links.