### PR TITLE
fix: remove phantom links around headings

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -50,22 +50,15 @@ Building a community of practice for data analysis and data science using open s
 ::: hero-buttons
 [Get Started](getting-started.qmd){.btn .btn-lg role="button"} [Get Involved](get-involved.qmd){.btn .btn-lg role="button"}
 :::
+
 :::
 
-<a href="blog/index.qmd" aria-label="Blog page">
-
-## Blog
-
-</a>
+## [Blog](blog/index.qmd)
 
 ::: {#blog}
 :::
 
-<a href="books/index.qmd" aria-label="Books page">
-
-## Books
-
-</a>
+## [Books](books/index.qmd)
 
 ::: {#books}
 :::
@@ -75,11 +68,7 @@ Building a community of practice for data analysis and data science using open s
 ::: footer-block
 ::: grid
 ::: {.g-col-12 .g-col-md-2}
-<a href="supporters.qmd" aria-label="Information about how to support NHS-R Community">
-
-## Supporters
-
-</a>
+## [Supporters](supporters.qmd){aria-label="Information about how to support NHS-R Community"}
 :::
 
 ::: {.g-col-12 .g-col-md-2}


### PR DESCRIPTION
Correction to hyperlinks on headings on the homepage so that empty hyperlinks don't appear before and after the headings. This affects accessibility for keyboard navigation users. Screenshots show tabbing orders.

Before changes, numerous empty links around the Blog, Books and Supporters headings:
![image](https://github.com/user-attachments/assets/958662df-02eb-4d8d-8be5-634e565c4835)

After changes
![image](https://github.com/user-attachments/assets/925323d7-8210-407e-a77e-3919aceb6bae)
