### PR TITLE
Fix focus visible issues on button styling

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -40,6 +40,15 @@ $code-block-bg:               #2c2825;
 $body-bg:                     #2c2825; // Background
 $body-fg:                     #f5f4f3;
 
+// Colour
+$blue:                       $nhs-Blue !default;
+$purple:                     $nhs-Purple !default;
+$pink:                       $nhs-Pink !default;
+$red:                        $nhs-Red !default;
+$orange:                     $nhs-Orange !default;
+$yellow:                     $nhs-Yellow !default;
+$green:                      $nhs-Green !default;
+
 // Links
 
 $link-decoration:             underline;
@@ -122,6 +131,12 @@ $footer-fg:                   $nhs-PaleGrey;
 // social links
 .link-dark.me-1 i {
   color: $nhs-PaleGrey !important;
+}
+
+// Button focus style
+.btn:focus-visible {
+  outline: 3px solid $body-color;
+  outline-offset: 2px;
 }
 
 // Footer

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -35,6 +35,15 @@ $link-color:                 $nhs-DarkGrey;
 // Banner
 $body-bg:                    $nhs-PaleGrey; // Background
 
+// Colour
+$blue:                       $nhs-Blue !default;
+$purple:                     $nhs-Purple !default;
+$pink:                       $nhs-Pink !default;
+$red:                        $nhs-Red !default;
+$orange:                     $nhs-Orange !default;
+$yellow:                     $nhs-Yellow !default;
+$green:                      $nhs-Green !default;
+
 // Links
 
 $link-decoration:             underline;
@@ -219,16 +228,10 @@ $footer-fg:                   $nhs-Pink;
   }
 }
 
-.btn {
-  background-color: $nhs-BrightBlue;
-  color: white;
+.btn:focus-visible {
+  outline: 3px solid $body-color;
+  outline-offset: 2px;
 }
-
-.btn:hover {
-      background-color: $nhs-LightBlue;
-      transition: 0.7s;
-      color: white;
-  }
 
 /*-- footer style --*/
 

--- a/index.qmd
+++ b/index.qmd
@@ -48,7 +48,7 @@ listing:
 Building a community of practice for data analysis and data science using open source software in the NHS and wider UK health and care system
 
 ::: hero-buttons
-[Get Started](getting-started.qmd){.btn .btn-lg role="button"} [Get Involved](get-involved.qmd){.btn .btn-lg role="button"}
+[Get Started](getting-started.qmd){.btn .btn-lg .btn-primary role="button"} [Get Involved](get-involved.qmd){.btn .btn-lg .btn-primary role="button"}
 :::
 :::
 


### PR DESCRIPTION
There are currently contrast failures on the "hero buttons" on the homepage, as `.btn:focus-visible` has an `outline:0` setting and a background colour that has no contrast to the background area. This makes the link disappear with no outline could be a failure of [WCAG 2.1 AA SC 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html). For example, the focus is currently on the "Get Started" button:

![image](https://github.com/user-attachments/assets/e5b25a1e-eb0e-4530-974e-d2778b077305)

This will adjust the following:

- Set Bootstrap colours to match NHS theme colours, in particular `$blue`, which is also the BS Primary context colour for this theme, is now mapped to `$nhs-Blue`.
- The hero buttons now use the `.btn-primary` class.
- Old styling rules in light theme for `.btn` are dropped
-  A custom `.btn:focus-visible` is inserted so ensure a strong outline is visible in both light and dark themes. The outline is set to the standard text colour for that theme.

For this demo, the buttons are set to primary and secondary, but in the actual code both are set to primary:

Light mode:
![image](https://github.com/user-attachments/assets/91d84791-2558-4b18-b626-d5cceb85db49)
when focused:
![image](https://github.com/user-attachments/assets/2ed9493b-8d80-4cdf-93d1-5c20ef6ae326)
![image](https://github.com/user-attachments/assets/eaf69d8f-133e-482c-8bdd-ea9b714123b2)

Dark mode:
![image](https://github.com/user-attachments/assets/a71ce32a-b7db-468d-a149-7363394d7f59)
when focused
![image](https://github.com/user-attachments/assets/f642eca0-12c3-47b6-a94e-1f49320bf618)
![image](https://github.com/user-attachments/assets/8984e4d3-6ade-4d1a-bc13-9320e27ab2cf)

Notes:

- Contrast between `btn-secondary` background and text colour is 4.69:1 AA compliant 
![image](https://github.com/user-attachments/assets/bb3f3dea-8360-4eb4-a8cc-36b6007d4565)
- This also affects the buttons on Books pages. e.g. https://nhsrcommunity.com/books/posts/NHSR-way/index.html but source code suggests these were meant to be "secondary" colour, which was meant to be grey in this theme.
- **Setting the CSS colours could affect other areas of the site, so please check for funny colours before proceeding**