### PR TITLE
fix: dark mode background and text contrast on conference page.

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -211,6 +211,11 @@ $footer-fg:                   $nhs-PaleGrey;
   }
 }
 
+.nav-tabs .nav-link.active {
+  color: $nhs-PaleGrey;
+  background-color: unset;
+}
+
 // subtitle
 .subtitle {
   font-size: 1.2em;
@@ -222,4 +227,9 @@ $footer-fg:                   $nhs-PaleGrey;
       text-decoration: none !important;
     }
   }
+}
+
+// Details Summary
+details > summary {
+  color: $nhs-PaleGrey;
 }

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -256,3 +256,8 @@ $footer-fg:                   $nhs-Pink;
 .white-background {
   background-color: white;
 }
+
+// Details Summary
+details > summary {
+  color: $nhs-DarkGrey;
+}

--- a/conference24.qmd
+++ b/conference24.qmd
@@ -4,7 +4,6 @@ page-layout: article
 toc: false
 title-block-banner: false
 code-fold: true
-backgroundcolor: white
 ---
 
 ![](img/rpysoc-24-banner.png){fig-alt="RPYSOC conference 2024 banner."}


### PR DESCRIPTION
Fixes #242 

Fixes fix to #234 

- Reinstate dark mode.
- Fix text contrast on links above conference table.