### PR TITLE
fix: Correction to site-url so 404 page can find its styling.

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,7 +4,7 @@ project:
 website:
   title: "NHS-R Community Quarto website"
   description: "Promoting the Use of R in the UK Health & Care System"
-  site-url: https://nhs-r-community.github.io/nhs-r-community/
+  site-url: https://nhsrcommunity.com/
   page-navigation: true
   back-to-top-navigation: true
   favicon: /img/nhsr-logo.png


### PR DESCRIPTION
Fixes #248 

The 404 page needs absolute file paths to find the CSS and JS assets to style and construct the page. It can't use relative file paths because the 404 page could be needed from any incorrect URL that can be multiple directories deep already.

To determine the absolute file path, it will look at the `site-url` if one exists and see if that URL has a slug. If it detects a slug, this will be included as the start of the absolute file path to the CSS assets. This is why all paths in the HTML `<head>` on the old 404 page started with /nhs-r-community:

![image](https://github.com/user-attachments/assets/f6347204-c3a5-4524-898f-7293204f397c)

This should remove those prefixes:

![image](https://github.com/user-attachments/assets/958c6a60-2361-4a04-a1da-cac483a0ebba)
