### PR TITLE
:fire: Remove duplicate site-url metadata

### DIFF
--- a/latest-content.qmd
+++ b/latest-content.qmd
@@ -1,7 +1,6 @@
 ---
 pagetitle: Latest content | NHS-R Community
 title: Latest content
-site-url: https://nhs-r-community.github.io/nhs-r-community/
 title-block-banner: true
 sidebar: false
 search: false


### PR DESCRIPTION
Already defined in `_quarto.yml`. Related to #250 