### PR TITLE
Change to a simple list of upcoming events, ordered by date

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1579,3 +1579,9 @@ RPYSoc
 Pluralsight
 upskilling
 Darzi
+afbc
+bea
+dac
+microsoft
+Passcode
+nEx

--- a/Current_Fellows.csv
+++ b/Current_Fellows.csv
@@ -1,8 +1,9 @@
-﻿Name,Organisation,Valid From
+Name,Organisation,Valid From
 Adrian Pratt,NHS Arden & GEM CSU,01/04/2025
 Anya Ferguson,The Strategy Unit,01/04/2025
 Caileigh Solomenca,The Strategy Unit,01/04/2025
 Chris Beeley,The Strategy Unit,01/04/2025
+Claire Welsh, The Strategy Unit, 01/04/2025
 Ellen Coughlan,The Health Foundation,01/04/2025
 Lyn Howard,NHS England,01/04/2025
 Pablo Leon-Rodenas,NHS England,01/04/2025
@@ -13,3 +14,4 @@ Bianca O’Mahoney,The Strategy Unit,01/01/2024
 Natasha Stephenson,The Strategy Unit,01/04/2024
 Simon Wellesley-Miller,NHS England,01/04/2025
 Anastasiia Zharinova,NHS England,01/04/2025
+

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -31,8 +31,8 @@ website:
         href: contact.qmd
         aria-label: About page
       - text: Events
-        href: https://events.nhsrcommunity.com/
-        aria-label: Events on Pretix
+        href: events.qmd
+        aria-label: List of upcoming events
       - text: conference
         href: conference24.qmd
         aria-label: conference page

--- a/events.qmd
+++ b/events.qmd
@@ -1,0 +1,46 @@
+---
+sidebar: false
+page-layout: article
+toc: false
+title-block-banner: true
+---
+
+## Upcoming NHS-R events
+
+-----
+
+### JUNE 2025
+
+📆 2nd,3rd Training: Intermediate R
+  + 09:00 - 13:00 (GMT)
+  + 🔗 Registration Links:
+  Day 1: https://events.teams.microsoft.com/event/e294e006-bc5e-48ab-b0b1-46e4c1a2cd15@f47807cf-afbc-4184-a579-8678bea3019a
+  Day 2: https://events.teams.microsoft.com/event/9d8566b2-035c-46ad-91a3-5d782dac1a1b@f47807cf-afbc-4184-a579-8678bea3019a
+
+📆 11th **Coffee and Coding**:
+  + 14:00 - 15:00 (GMT)
+  + 🔗 [Meeting Link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2RjNTk0ZjItZmYzMS00ZTNlLTgyNzgtNWIzNjE1MmUyNTM3%40thread.v2/0?context=%7b%22Tid%22%3a%2237c354b2-85b0-47f5-b222-07b48d774ee3%22%2c%22Oid%22%3a%22a530dd85-162a-4e04-9d49-b8fd329ec75c%22%7d)
+  + Meeting ID: 331 945 876 23
+  + Passcode: Po2nEx
+  
+📆 27th **Coffee and Coding**:
+  + 11:00 - 12:00 (GMT)
+  + 🔗 [Meeting Link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2RjNTk0ZjItZmYzMS00ZTNlLTgyNzgtNWIzNjE1MmUyNTM3%40thread.v2/0?context=%7b%22Tid%22%3a%2237c354b2-85b0-47f5-b222-07b48d774ee3%22%2c%22Oid%22%3a%22a530dd85-162a-4e04-9d49-b8fd329ec75c%22%7d)
+  + Meeting ID: 331 945 876 23
+  + Passcode: Po2nEx
+  
+------
+
+### JULY 2025
+
+📆 10th **Coffee and Coding**:
+  + 14:00 - 15:00 (GMT)
+  + 🔗 [Meeting Link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2RjNTk0ZjItZmYzMS00ZTNlLTgyNzgtNWIzNjE1MmUyNTM3%40thread.v2/0?context=%7b%22Tid%22%3a%2237c354b2-85b0-47f5-b222-07b48d774ee3%22%2c%22Oid%22%3a%22a530dd85-162a-4e04-9d49-b8fd329ec75c%22%7d)
+  + Meeting ID: 331 945 876 23
+  + Passcode: Po2nEx
+  
+📆 23rd **Coffee and Coding**:
+  + 14:00 - 15:00 (GMT)
+  + 🔗 [Meeting Link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2RjNTk0ZjItZmYzMS00ZTNlLTgyNzgtNWIzNjE1MmUyNTM3%40thread.v2/0?context=%7b%22Tid%22%3a%2237c354b2-85b0-47f5-b222-07b48d774ee3%22%2c%22Oid%22%3a%22a530dd85-162a-4e04-9d49-b8fd329ec75c%22%7d)
+  + Meeting ID: 331 945 876 23
+  + Passcode: Po2nEx


### PR DESCRIPTION
In advance of simplifying booking (removing dependence on Pretix) I've changed the events page from a link that takes the user out to a calendar view, to a more simple quarto list of upcoming events that can be managed more easily in house