### PR TITLE
🔒️ Protect GitHub actions in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # @primary-owner and @secondary-owner will be requested for
 # review when someone opens a pull request.
 *       @DCEW @ChrisBeeley
+.github/ @nhs-r-community/security


### PR DESCRIPTION
- Have added the [security team](https://github.com/orgs/nhs-r-community/teams/security) as CODEOWNERS for `.github/` folder

@DCEW We talked about changing the CODEOWNERS to all eight people in the [admin team](https://github.com/orgs/nhs-r-community/teams/admins). However, that feels like a lot of people to be pinged. So maybe just leave as you + Chris and another? What do you think?